### PR TITLE
use the new tap for brew cask, the old one was deprecated

### DIFF
--- a/osx-bootstrap
+++ b/osx-bootstrap
@@ -41,7 +41,7 @@ if ! which brew >/dev/null; then
 fi
 
 # install cask
-brew tap caskroom/cask
+brew tap homebrew/cask
 
 # install simple config manager
 gimme stow


### PR DESCRIPTION
change the tap endpoint to `homebrew/cask` due to the old tap caskroom/cask was deprecated.